### PR TITLE
Rework the EthercatMasterSingleton to properly handle usage from multiple ROS2control hardware interface

### DIFF
--- a/include/ethercat_sdk_master/EthercatMaster.hpp
+++ b/include/ethercat_sdk_master/EthercatMaster.hpp
@@ -46,7 +46,7 @@ namespace ecat_master {
  */
 class EthercatMaster {
  public:
-  typedef std::shared_ptr<EthercatMaster> SharedPtr;
+  using SharedPtr = std::shared_ptr<EthercatMaster>;
 
  public:
   EthercatMaster() = default;
@@ -176,6 +176,7 @@ class EthercatMaster {
    * from core to core. Default -1: Dont attach to any core. Has to be < than number of avaible cores
    * @return True if successful
    */
+  [[deprecated("Use ROS realtime_tools package instead")]]
   bool setRealtimePriority(int priority = 99, int cpu_core = -1) const;
 
   /*!

--- a/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
+++ b/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
@@ -140,12 +140,13 @@ namespace ecat_master
          * @brief releaseMaster - release your handle obtain via aquireMaster
          * This method decrements the internal reference counter for the given EthercatMaster and performs the shutdown if no references are living anymore
          */
-        bool releaseMaster(const std::shared_ptr<EthercatMaster> &master)
+        bool releaseMaster(const Handle &handle)
         {
             // Give it at least some thread safety
             std::lock_guard<std::mutex> guard(lock_);
-
-            const auto &network_interface = master->getConfiguration().networkInterface;
+            
+          
+            const auto &network_interface = handle.ecat_master->getConfiguration().networkInterface;
             // First check if we even handle this ethercat master
             if (!hasMaster(network_interface))
             {
@@ -158,7 +159,7 @@ namespace ecat_master
             if (handles_.at(network_interface).reference_count <= 0)
             {
                 // Perform the actual shutdown if all callers have called shutdown on their reference
-                shutdownMaster(master);
+                shutdownMaster(handle.ecat_master);
                 return true;
             }
 

--- a/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
+++ b/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
@@ -158,6 +158,7 @@ namespace ecat_master
 
             if (handles_.at(network_interface).reference_count <= 0)
             {
+                MELO_INFO_STREAM("Shutting down EthercatMaster for interface: " << network_interface );
                 // Perform the actual shutdown if all callers have called shutdown on their reference
                 shutdownMaster(handle.ecat_master);
                 return true;

--- a/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
+++ b/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
@@ -12,7 +12,13 @@ namespace ecat_master {
         public:
             static EthercatMasterSingleton&  instance(); //Method has to be in cpp file in order to work properly
 
-            std::shared_ptr<EthercatMaster> get(const EthercatMasterConfiguration& config) {
+            /**
+             * @brief get a shared pointer to an ecat master instance
+             * If there is already a master active for the given instance we simply reuse it and return it
+             * @note Using this methods enforces asynchronous spinning of the master in this class
+             * @note In case the "new" ethercat master configuration does not match the existing one only a warning is printed!
+             */
+            std::shared_ptr<EthercatMaster> get(const EthercatMasterConfiguration& config, int rt_prio = 48) {
                 std::lock_guard<std::recursive_mutex> guard(lock_);
 
                 if(ecat_masters_.find(config.networkInterface) == ecat_masters_.end())
@@ -24,7 +30,7 @@ namespace ecat_master {
                     ecat_masters_[config.networkInterface] = master;
                     
                     //Spin the master asynchronously
-                    spin_threads_.emplace(config.networkInterface, std::make_unique<std::thread>(std::bind(&EthercatMasterSingleton::spin,this, std::placeholders::_1), master));
+                    spin_threads_.emplace(config.networkInterface, std::make_unique<std::thread>(std::bind(&EthercatMasterSingleton::spin,this, std::placeholders::_1, std::placeholders::_2), master, rt_prio));
                 }
                 
                 if(config != ecat_masters_[config.networkInterface]->getConfiguration()){
@@ -32,7 +38,7 @@ namespace ecat_master {
                     MELO_WARN_STREAM("Ethercat master configurations do not match for bus: " << config.networkInterface);
                 }
 
-                return ecat_masters_[config.networkInterface];
+                return ecat_masters_.at(config.networkInterface);
             }
 
             bool hasMaster(const EthercatMasterConfiguration& config){
@@ -44,6 +50,10 @@ namespace ecat_master {
 
             std::shared_ptr<EthercatMaster> operator[] (const EthercatMasterConfiguration& config){
                 return get(config);
+            }
+
+            bool shutdown(std::shared_ptr<EthercatMaster> master){
+                return true;
             }
         private:
 
@@ -61,8 +71,9 @@ namespace ecat_master {
                 master->shutdown();
             }
         }
-        void spin(std::shared_ptr<EthercatMaster> master_){
-            master_->setRealtimePriority(); 
+        void spin(std::shared_ptr<EthercatMaster> master_, int rt_prio){
+            //We override the default rt prio of 99 as this might starve kernel threads. 
+            master_->setRealtimePriority(rt_prio); 
             while(!abort_){
                 master_->update(UpdateMode::StandaloneEnforceRate);
             }
@@ -70,6 +81,7 @@ namespace ecat_master {
 
         std::map<std::string,std::shared_ptr<EthercatMaster>> ecat_masters_;
         std::map<std::string, std::unique_ptr<std::thread>> spin_threads_;
+        std::map<std::string, std::atomic_bool> abort_signals_;
         std::recursive_mutex lock_;
         std::atomic_bool abort_ = false;
     };

--- a/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
+++ b/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
@@ -3,87 +3,166 @@
 #include <ethercat_sdk_master/EthercatMaster.hpp>
 #include <map>
 
-namespace ecat_master {
+namespace ecat_master
+{
     /**
      *  @brief Provides the only method how we can use the same ethercat bus in multiple ros2control hardware interfaces
      * The idea is that we centrally manage the instances of the EthercatMasters and each hardware interface may attach its devices to it
-    */
-    class EthercatMasterSingleton {
-        public:
-            static EthercatMasterSingleton&  instance(); //Method has to be in cpp file in order to work properly
+     */
+    class EthercatMasterSingleton
+    {
+    public:
+        static EthercatMasterSingleton &instance(); // Method has to be in cpp file in order to work properly
 
-            /**
-             * @brief get a shared pointer to an ecat master instance
-             * If there is already a master active for the given instance we simply reuse it and return it
-             * @note Using this methods enforces asynchronous spinning of the master in this class
-             * @note In case the "new" ethercat master configuration does not match the existing one only a warning is printed!
-             */
-            std::shared_ptr<EthercatMaster> get(const EthercatMasterConfiguration& config, int rt_prio = 48) {
-                std::lock_guard<std::recursive_mutex> guard(lock_);
+        /**
+         * @brief get a shared pointer to an ecat master instance
+         * If there is already a master active for the given instance we simply reuse it and return it
+         * @note Using this methods enforces asynchronous spinning of the master in this class
+         * @note In case the "new" ethercat master configuration does not match the existing one only a warning is printed!
+         */
+        std::shared_ptr<EthercatMaster> aquireMaster(const EthercatMasterConfiguration &config, int rt_prio = 48)
+        {
+            // Give it at least some thread safety
+            std::lock_guard<std::mutex> guard(lock_);
 
-                if(ecat_masters_.find(config.networkInterface) == ecat_masters_.end())
-                {
-                    MELO_INFO_STREAM("Setting up new EthercatMaster on interface: " << config.networkInterface << " and updating it");
-                    auto master = std::make_shared<EthercatMaster>();
-                    master->loadEthercatMasterConfiguration(config);
+            // Check if we already have a master up and running for the given networkinterface
+            if (ecat_masters_.find(config.networkInterface) == ecat_masters_.end())
+            {
+                MELO_INFO_STREAM("Setting up new EthercatMaster on interface: " << config.networkInterface << " and updating it");
+                auto master = std::make_shared<EthercatMaster>();
+                master->loadEthercatMasterConfiguration(config);
 
-                    ecat_masters_[config.networkInterface] = master;
-                    
-                    //Spin the master asynchronously
-                    spin_threads_.emplace(config.networkInterface, std::make_unique<std::thread>(std::bind(&EthercatMasterSingleton::spin,this, std::placeholders::_1, std::placeholders::_2), master, rt_prio));
-                }
-                
-                if(config != ecat_masters_[config.networkInterface]->getConfiguration()){
-                    //Print warning or abort if the configuration does not match!
-                    MELO_WARN_STREAM("Ethercat master configurations do not match for bus: " << config.networkInterface);
-                }
-
-                return ecat_masters_.at(config.networkInterface);
+                ecat_masters_[config.networkInterface] = master;
+                abort_signals_[config.networkInterface] = false;
+                reference_count_[config.networkInterface] = 1;
+                // Spin the master asynchronously
+                spin_threads_.emplace(config.networkInterface, std::make_unique<std::thread>(std::bind(&EthercatMasterSingleton::spin, this, std::placeholders::_1, std::placeholders::_2), master, rt_prio));
+            }
+            else
+            {
+                // In case we already handle the network interface we just increate its reference counter and return the instance
+                reference_count_[config.networkInterface] += 1;
             }
 
-            bool hasMaster(const EthercatMasterConfiguration& config){
-                return ecat_masters_.find(config.networkInterface) != ecat_masters_.end();
-            }
-            bool hasMaster(const std::string& networkInterface) {
-                return ecat_masters_.find(networkInterface) != ecat_masters_.end();
-            }
-
-            std::shared_ptr<EthercatMaster> operator[] (const EthercatMasterConfiguration& config){
-                return get(config);
+            if (config != ecat_masters_[config.networkInterface]->getConfiguration())
+            {
+                // Print warning or abort if the configuration does not match!
+                MELO_WARN_STREAM("Ethercat master configurations do not match for bus: " << config.networkInterface);
             }
 
-            bool shutdown(std::shared_ptr<EthercatMaster> master){
+            return ecat_masters_.at(config.networkInterface);
+        }
+
+        bool hasMaster(const EthercatMasterConfiguration &config)
+        {
+            return ecat_masters_.find(config.networkInterface) != ecat_masters_.end();
+        }
+        bool hasMaster(const std::string &networkInterface)
+        {
+            return ecat_masters_.find(networkInterface) != ecat_masters_.end();
+        }
+
+        /**
+         * @brief releaseMaster - release your handle obtain via aquireMaster
+         * This method decrements the internal reference counter for the given EthercatMaster and performs the shutdown if no references are living anymore
+         */
+        bool releaseMaster(const std::shared_ptr<EthercatMaster> &master)
+        {
+            // Give it at least some thread safety
+            std::lock_guard<std::mutex> guard(lock_);
+
+            const auto &network_interface = master->getConfiguration().networkInterface;
+            // First check if we even handle this ethercat master
+            if (!hasMaster(network_interface))
+            {
+                throw std::logic_error("EthercatMaster for interface: " + network_interface + " is not handled by this singleton");
+            }
+
+            // Decrement the reference counter and check if it is zero
+            reference_count_[network_interface] -= 1;
+
+            if (reference_count_[network_interface] <= 0)
+            {
+                // Perform the actual shutdown if all callers have called shutdown on their reference
+                shutdownMaster(master);
                 return true;
             }
-        private:
 
-        EthercatMasterSingleton(){
-
+            return false;
         }
-        ~EthercatMasterSingleton() {
-            abort_ = true;
+        void forceShutdownMaster(const std::shared_ptr<EthercatMaster> &master)
+        {
 
-            for(const auto& [interface, thread]: spin_threads_){
+            // Give it at least some thread safety
+            std::lock_guard<std::mutex> guard(lock_);
+
+            shutdownMaster(master);
+        }
+
+    private:
+        void shutdownMaster(const std::shared_ptr<EthercatMaster> &master, bool set_to_safe_op = true)
+        {
+            const auto &network_interface = master->getConfiguration().networkInterface;
+            if (!hasMaster(network_interface))
+            {
+                throw std::logic_error("EthercatMaster for interface: " + network_interface + " is not handled by this singleton");
+            }
+
+            // Tell the update thread of the corresponding master to stop spinning
+            abort_signals_[network_interface] = true;
+
+            // Wait for the thread to end
+            spin_threads_[network_interface]->join();
+
+            // Perform the actuall shutdown
+            ecat_masters_[network_interface]->preShutdown(set_to_safe_op);
+            ecat_masters_[network_interface]->shutdown();
+
+            // And remove all entries
+            abort_signals_.erase(network_interface);
+            spin_threads_.erase(network_interface);
+            ecat_masters_.erase(network_interface);
+            reference_count_.erase(network_interface);
+        }
+
+        EthercatMasterSingleton() = default;
+        ~EthercatMasterSingleton()
+        {
+            // Tell every update thread to stop spinning
+            for (auto &[interface, abort_flag] : abort_signals_)
+            {
+                abort_flag = true;
+            }
+            // Wait for the threads to end
+            for (const auto &[interface, thread] : spin_threads_)
+            {
                 thread->join();
             }
-            for(const auto &  [interfrace, master]: ecat_masters_){
+            for (const auto &[interfrace, master] : ecat_masters_)
+            {
                 master->preShutdown();
                 master->shutdown();
             }
         }
-        void spin(std::shared_ptr<EthercatMaster> master_, int rt_prio){
-            //We override the default rt prio of 99 as this might starve kernel threads. 
-            master_->setRealtimePriority(rt_prio); 
-            while(!abort_){
+        void spin(const std::shared_ptr<EthercatMaster>& master_, int rt_prio)
+        {
+
+            // Obtain a reference to the abort floag
+            auto &abort_flag = abort_signals_[master_->getConfiguration().networkInterface];
+            // We override the default rt prio of 99 as this might starve kernel threads.
+            master_->setRealtimePriority(rt_prio);
+            while (!abort_flag)
+            {
                 master_->update(UpdateMode::StandaloneEnforceRate);
             }
         }
 
-        std::map<std::string,std::shared_ptr<EthercatMaster>> ecat_masters_;
+        std::map<std::string, std::shared_ptr<EthercatMaster>> ecat_masters_;
         std::map<std::string, std::unique_ptr<std::thread>> spin_threads_;
         std::map<std::string, std::atomic_bool> abort_signals_;
-        std::recursive_mutex lock_;
-        std::atomic_bool abort_ = false;
+        std::map<std::string, int> reference_count_;
+
+        std::mutex lock_;
     };
 
 }

--- a/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
+++ b/include/ethercat_sdk_master/EthercatMasterSingleton.hpp
@@ -81,7 +81,7 @@ namespace ecat_master
             // 1. find the corresponding internal handle
             const auto &network_interface = handle.ecat_master->getConfiguration().networkInterface;
 
-            if (hasMaster(network_interface))
+            if (!hasMaster(network_interface))
             {
                 throw std::logic_error("EthercatMaster for interface: " + network_interface + " is not handled by this singleton");
             }
@@ -92,7 +92,7 @@ namespace ecat_master
 
             if (internal_handle.handles_ready.at(handle.id))
             {
-                throw std::runtime_error("Handle with id: " + std::to_string(handle.id) + " on interface: " + network_interface);
+                throw std::runtime_error("Handle with id: " + std::to_string(handle.id) + " on interface: " + network_interface + " was already marked as ready!");
             }
 
             // 3. Mark it as ready
@@ -111,7 +111,8 @@ namespace ecat_master
             }
 
             if (!all_ready)
-            {
+            {   
+                MELO_INFO_STREAM("Not all handles ready - defering start");
                 return false;
             }
 
@@ -120,8 +121,9 @@ namespace ecat_master
             {
                 throw std::runtime_error("Could not startup ethercat master on interface: " + network_interface);
             }
+            MELO_INFO_STREAM("Starting asynchronous worker thread for ethercat master on network interface: "  << network_interface);
             // Spin the master asynchronously
-            // internal_handle.spin_thread = std::make_unique<std::thread>(std::bind(&EthercatMasterSingleton::spin, this, std::placeholders::_1),network_interface);
+            internal_handle.spin_thread = std::make_unique<std::thread>(std::bind(&EthercatMasterSingleton::spin, this, std::placeholders::_1),network_interface);
         }
         /**
          * @brief check if an ethercat master is active and managed by this implementation for the given configuration


### PR DESCRIPTION
This is a necessary feature in order to support multiple arms (or other devices) with our ros2control driver on the same Ethercat Bus. 


In the current state some stuff is still missing which is necessary for the proper setup of the bus. 
For example I am not sure if we can currently add new devices to an already running bus...